### PR TITLE
Avoid opt-level=z

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ debug = 1
 debug-assertions = true # <-
 incremental = false
 lto = 'fat'
-opt-level = 'z' # <-
+opt-level = 3 # <-
 overflow-checks = true # <-
 
 [profile.release]


### PR DESCRIPTION
Avoids https://github.com/rust-lang/rust/issues/75045, which you would otherwise hit when using the nRF HAL.