### PR TITLE
Don't enable LTO in the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ codegen-units = 1
 debug = 2
 debug-assertions = true # <-
 incremental = false
-lto = 'fat'
 opt-level = 3 # <-
 overflow-checks = true # <-
 


### PR DESCRIPTION
This works around https://github.com/rust-lang/cargo/issues/3244, which would otherwise cause rebuilds of the entire crate graph for no reason.