### PR TITLE
Use panic-probe instead of a custom panic handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ branch = "main"
 git = "https://github.com/knurling-rs/defmt"
 branch = "main"
 
+[dependencies.panic-probe]
+git = "https://github.com/knurling-rs/probe-run"
+branch = "main"
+
 [dependencies]
 cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use defmt_rtt as _; // global logger
-
+use panic_probe as _;
 // TODO(5) adjust HAL import
 // use some_hal as _; // memory layout
 
@@ -14,23 +14,6 @@ fn timestamp() -> u64 {
     let n = COUNT.load(Ordering::Relaxed);
     COUNT.store(n + 1, Ordering::Relaxed);
     n as u64
-}
-
-#[panic_handler] // panicking behavior
-fn panic(info: &core::panic::PanicInfo) -> ! {
-    if let Some(loc) = info.location() {
-        defmt::error!(
-            "panicked at {:str}:{:u32}:{:u32}",
-            loc.file(),
-            loc.line(),
-            loc.column()
-        )
-    } else {
-        // no location info
-        defmt::error!("panicked")
-    }
-
-    exit()
 }
 
 /// Terminates the application and makes `probe-run` exit with exit-code = 0


### PR DESCRIPTION
panic-probe is needed for on-device integration tests, and would conflict with the hand-rolled panic handler that is currently present.