### PR TITLE
Add an on-device test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,12 @@ name = "{{project-name}}"
 edition = "2018"
 version = "0.1.0"
 
+[lib]
+test = false
+
+[workspace]
+members = ["testsuite"]
+
 [dependencies.defmt]
 git = "https://github.com/knurling-rs/defmt"
 branch = "main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,6 @@ name = "{{project-name}}"
 edition = "2018"
 version = "0.1.0"
 
-[lib]
-test = false
-
 [workspace]
 members = ["testsuite"]
 

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+# TODO(1) fix `authors` if you didn't use `cargo-generate`
+authors = ["{{authors}}"]
+name = "testsuite"
+publish = false
+edition = "2018"
+version = "0.1.0"
+
+[[test]]
+name = "test"
+harness = false
+
+[dependencies.defmt]
+git = "https://github.com/knurling-rs/defmt"
+branch = "main"
+
+[dependencies.defmt-rtt]
+git = "https://github.com/knurling-rs/defmt"
+branch = "main"
+
+[dependencies.panic-probe]
+git = "https://github.com/knurling-rs/probe-run"
+branch = "main"
+# enable the `print-defmt` feature for more complete test output
+features = ["print-defmt"]
+
+[dependencies]
+{{project-name}} = { path = ".." }
+cortex-m = "0.6.3"
+cortex-m-rt = "0.6.12"
+
+[features]
+# set logging levels here
+default = [
+  # in tests, enable all logs
+  "defmt-trace",
+  # "dependency-a/defmt-trace",
+]
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/testsuite/tests/test.rs
+++ b/testsuite/tests/test.rs
@@ -1,0 +1,12 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use {{project-name}} as _; // memory layout + panic handler
+
+#[entry]
+fn main() -> ! {
+    assert!(false, "TODO: Write actual tests");
+
+    {{project-name}}::exit();
+}

--- a/testsuite/tests/test.rs
+++ b/testsuite/tests/test.rs
@@ -2,11 +2,11 @@
 #![no_main]
 
 use cortex_m_rt::entry;
-use {{project-name}} as _; // memory layout + panic handler
+use {{crate_name}} as _; // memory layout + panic handler
 
 #[entry]
 fn main() -> ! {
     assert!(false, "TODO: Write actual tests");
 
-    {{project-name}}::exit();
+    {{crate_name}}::exit();
 }


### PR DESCRIPTION
This adds a package with integration tests that will run on the device. This can be done via `cargo test -p testsuite` or by clicking rust-analyzer's "Run" button on the test. Any panic will fail the test, as you would expect.