### PR TITLE
Exclude funding info from template

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+exclude = [".github/FUNDING.yml"]


### PR DESCRIPTION
Otherwise this gets put into every repo created from this, which probably isn't the nicest thing to do