### PR TITLE
Added README.md to cargo-generate.toml excludes

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,2 +1,2 @@
 [template]
-exclude = [".github/FUNDING.yml"]
+exclude = [".github/FUNDING.yml", "README.md"]


### PR DESCRIPTION
A recent commit [8b9e0f5 ](https://github.com/knurling-rs/app-template/commit/8b9e0f5ec089bf980d53a44f0dfbc0edf9326390)has broken `cargo generate` due to introducing the text `{{chip}}` in `README.md` which is being mistaken for Liquid template syntax by `cargo generate`. As `README.md` never needs to have its content processed by `cargo generate`, excluding it seems appropriate.

```
cargo generate --git https://github.com/knurling-rs/app-template --branch main --name knurling-co2
 Creating project called `knurling-co2`...
Error:  Error replacing placeholders `C:\rust\knurling-co2\README.md`

Caused by:
    liquid: Unknown variable
      with:
        requested variable=chip
        available variables=authors, crate_name, project-name
```