### PR TITLE
use crates.io versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,21 +8,12 @@ version = "0.1.0"
 [workspace]
 members = ["testsuite"]
 
-[dependencies.defmt]
-git = "https://github.com/knurling-rs/defmt"
-branch = "main"
-
-[dependencies.defmt-rtt]
-git = "https://github.com/knurling-rs/defmt"
-branch = "main"
-
-[dependencies.panic-probe]
-git = "https://github.com/knurling-rs/probe-run"
-branch = "main"
-
 [dependencies]
 cortex-m = "0.6.4"
 cortex-m-rt = "0.6.13"
+defmt = "0.1.0"
+defmt-rtt = "0.1.0"
+panic-probe = { version = "0.1.0", features = ["print-defmt"] }
 # TODO(4) enter your HAL here
 # some-hal = "1.2.3"
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,10 @@
 $ cargo install flip-link
 ```
 
-#### 2. The **git** version of `probe-run`:
+#### 2. `probe-run`:
 
-<!-- TODO: update this once defmt is on crates.io? -->
 ``` console
-$ cargo install \
-    --git https://github.com/knurling-rs/probe-run \
-    --branch main \
-    --features defmt
+$ cargo install probe-run
 ```
 
 #### 3. [`cargo-generate`]:

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -10,24 +10,13 @@ version = "0.1.0"
 name = "test"
 harness = false
 
-[dependencies.defmt]
-git = "https://github.com/knurling-rs/defmt"
-branch = "main"
-
-[dependencies.defmt-rtt]
-git = "https://github.com/knurling-rs/defmt"
-branch = "main"
-
-[dependencies.panic-probe]
-git = "https://github.com/knurling-rs/probe-run"
-branch = "main"
-# enable the `print-defmt` feature for more complete test output
-features = ["print-defmt"]
-
 [dependencies]
 {{project-name}} = { path = ".." }
 cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
+defmt = "0.1.0"
+defmt-rtt = "0.1.0"
+panic-probe = { version = "0.1.0", features = ["print-defmt" ] }
 
 [features]
 # set logging levels here


### PR DESCRIPTION
also enable panic-probe's 'print-defmt' so panic messages are printed

~~blocked on crates.io release~~