### PR TITLE
Remove proc macro opt-level override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,18 +57,3 @@ incremental = false
 lto = 'fat'
 opt-level = 3 # <-
 overflow-checks = false # <-
-
-# do not optimize proc-macro crates = faster builds from scratch
-[profile.dev.build-override]
-codegen-units = 8
-debug = false
-debug-assertions = false
-opt-level = 0
-overflow-checks = false
-
-[profile.release.build-override]
-codegen-units = 8
-debug = false
-debug-assertions = false
-opt-level = 0
-overflow-checks = false


### PR DESCRIPTION
I believe Cargo now does this by default