### PR TITLE
use defmt-test in the test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,5 @@ overflow-checks = false # <-
 # [patch.crates-io]
 # defmt = { git = "https://github.com/knurling-rs/defmt", rev = "use defmt version reported by `probe-run --version`" }
 # defmt-rtt = { git = "https://github.com/knurling-rs/defmt", rev = "use defmt version reported by `probe-run --version`" }
+# defmt-test = { git = "https://github.com/knurling-rs/defmt", rev = "use defmt version reported by `probe-run --version`" }
 # panic-probe = { git = "https://github.com/knurling-rs/defmt", rev = "use defmt version reported by `probe-run --version`" }

--- a/README.md
+++ b/README.md
@@ -158,10 +158,12 @@ In the example output, the supported version is `3db6b41f08a5c866e6d6ed7103d01b0
 -# [patch.crates-io]
 -# defmt = { git = "https://github.com/knurling-rs/defmt", rev = "use defmt version reported by `probe-run --version`" }
 -# defmt-rtt = { git = "https://github.com/knurling-rs/defmt", rev = "use defmt version reported by `probe-run --version`" }
+-# defmt-test = { git = "https://github.com/knurling-rs/defmt", rev = "use defmt version reported by `probe-run --version`" }
 -# panic-probe = { git = "https://github.com/knurling-rs/defmt", rev = "use defmt version reported by `probe-run --version`" }
 +[patch.crates-io]
 +defmt = { git = "https://github.com/knurling-rs/defmt", rev = "3db6b41f08a5c866e6d6ed7103d01b0b0fe5a1f4" }
 +defmt-rtt = { git = "https://github.com/knurling-rs/defmt", rev = "3db6b41f08a5c866e6d6ed7103d01b0b0fe5a1f4" }
++defmt-test = { git = "https://github.com/knurling-rs/defmt", rev = "3db6b41f08a5c866e6d6ed7103d01b0b0fe5a1f4" }
 +panic-probe = { git = "https://github.com/knurling-rs/defmt", rev = "3db6b41f08a5c866e6d6ed7103d01b0b0fe5a1f4" }
 ```
 

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -16,6 +16,7 @@ cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
 defmt = "0.1.0"
 defmt-rtt = "0.1.0"
+defmt-test = "0.1.0"
 panic-probe = { version = "0.1.0", features = ["print-defmt" ] }
 
 [features]

--- a/testsuite/tests/test.rs
+++ b/testsuite/tests/test.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use cortex_m_rt::entry;
 use {{crate_name}} as _; // memory layout + panic handler
 
 // See https://crates.io/crates/defmt-test/0.1.0 for more documentation (e.g. about the 'state'

--- a/testsuite/tests/test.rs
+++ b/testsuite/tests/test.rs
@@ -4,7 +4,8 @@
 use cortex_m_rt::entry;
 use {{crate_name}} as _; // memory layout + panic handler
 
-// See https://crates.io/crates/defmt-test/0.1.0 for more documentation
+// See https://crates.io/crates/defmt-test/0.1.0 for more documentation (e.g. about the 'state'
+// feature)
 #[defmt_test::tests]
 mod tests {
     #[test]

--- a/testsuite/tests/test.rs
+++ b/testsuite/tests/test.rs
@@ -4,9 +4,16 @@
 use cortex_m_rt::entry;
 use {{crate_name}} as _; // memory layout + panic handler
 
-#[entry]
-fn main() -> ! {
-    assert!(false, "TODO: Write actual tests");
+// See https://crates.io/crates/defmt-test/0.1.0 for more documentation
+#[defmt_test::tests]
+mod tests {
+    #[test]
+    fn assert_true() {
+        assert!(true)
+    }
 
-    {{crate_name}}::exit();
+    #[test]
+    fn assert_false() {
+        assert!(false, "TODO: write actual tests")
+    }
 }


### PR DESCRIPTION
must be merged after `defmt-test` has been published on crates.io