### PR TITLE
use defmt::assert; add defmt::panic_hnadler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["testsuite"]
 [dependencies]
 cortex-m = "0.6.4"
 cortex-m-rt = "0.6.13"
-defmt = "0.1.0"
+defmt = "0.1.2"
 defmt-rtt = "0.1.0"
 panic-probe = { version = "0.1.0", features = ["print-defmt"] }
 # TODO(4) enter your HAL here

--- a/src/bin/panic.rs
+++ b/src/bin/panic.rs
@@ -7,5 +7,5 @@ use {{crate_name}} as _; // global logger + panicking-behavior + memory layout
 fn main() -> ! {
     defmt::info!("main");
 
-    panic!()
+    defmt::panic!()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,17 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use defmt_rtt as _; // global logger
-use panic_probe as _;
 // TODO(5) adjust HAL import
 // use some_hal as _; // memory layout
+
+use panic_probe as _;
+
+// same panicking *behavior* as `panic-probe` but doesn't print a panic message
+// this prevents the panic message being printed *twice* when `defmt::panic` is invoked
+#[defmt::panic_handler]
+fn panic() -> ! {
+    cortex_m::asm::udf()
+}
 
 #[defmt::timestamp]
 fn timestamp() -> u64 {

--- a/testsuite/tests/test.rs
+++ b/testsuite/tests/test.rs
@@ -2,6 +2,7 @@
 #![no_main]
 
 use {{crate_name}} as _; // memory layout + panic handler
+use defmt::{assert, assert_eq};
 
 // See https://crates.io/crates/defmt-test/0.1.0 for more documentation (e.g. about the 'state'
 // feature)
@@ -13,7 +14,7 @@ mod tests {
     }
 
     #[test]
-    fn assert_false() {
-        assert!(false, "TODO: write actual tests")
+    fn assert_eq() {
+        assert_eq!(24, 42, "TODO: write actual tests")
     }
 }


### PR DESCRIPTION
switch test-suite from core::assert to defmt assertions which sport color diffs
it also adds a defmt::panic_handler to avoid the panic message being printed twice on defmt::panic (as documented in the defmt book)
this PR is blocked on the release of defmt v0.1.2