### PR TITLE
Actually use the defmt assertion macros

### DIFF
--- a/testsuite/tests/test.rs
+++ b/testsuite/tests/test.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use {{crate_name}} as _; // memory layout + panic handler
-use defmt::{assert, assert_eq};
 
 // See https://crates.io/crates/defmt-test/0.1.0 for more documentation (e.g. about the 'state'
 // feature)
@@ -10,11 +9,11 @@ use defmt::{assert, assert_eq};
 mod tests {
     #[test]
     fn assert_true() {
-        assert!(true)
+        defmt::assert!(true)
     }
 
     #[test]
     fn assert_eq() {
-        assert_eq!(24, 42, "TODO: write actual tests")
+        defmt::assert_eq!(24, 42, "TODO: write actual tests")
     }
 }


### PR DESCRIPTION
The imports were unused, the libcore macros were still in use. Qualify them as `defmt::assert*` instead.