### PR TITLE
Remove `--defmt` flag from probe-run

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # TODO(2) replace `$CHIP` with your chip's name (see `probe-run --list-chips` output)
-runner = "probe-run --chip $CHIP --defmt"
+runner = "probe-run --chip $CHIP"
 rustflags = [
   "-C", "linker=flip-link",
   "-C", "link-arg=-Tlink.x",


### PR DESCRIPTION
This now gets automatically detected