### PR TITLE
Use defmt:timestamp! macro instead of attribute form

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,8 @@ fn panic() -> ! {
     cortex_m::asm::udf()
 }
 
-#[defmt::timestamp]
-fn timestamp() -> u64 {
-    static COUNT: AtomicUsize = AtomicUsize::new(0);
-    // NOTE(no-CAS) `timestamps` runs with interrupts disabled
-    let n = COUNT.load(Ordering::Relaxed);
-    COUNT.store(n + 1, Ordering::Relaxed);
-    n as u64
-}
+static COUNT: AtomicUsize = AtomicUsize::new(0);
+defmt::timestamp!("{=usize}", COUNT.fetch_add(1, Ordering::Relaxed));
 
 /// Terminates the application and makes `probe-run` exit with exit-code = 0
 pub fn exit() -> ! {


### PR DESCRIPTION
This change fixes a compiler error in the CO2 sensor sessions:
```
error: expected attribute, found macro `defmt::timestamp`
  --> src/lib.rs:18:3
   |
18 | #[defmt::timestamp]
   |   ^^^^^^^^^^^^^^^^ not an attribute
```

> The #[defmt::timestamp] attribute has been changed to a regular macro that works just like the logging macros

Cite: https://ferrous-systems.com/blog/knurling-changelog-13/