### PR TITLE
add debuginfo to `test --release`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ defmt-info = []
 defmt-warn = []
 defmt-error = []
 
+# cargo build/run
 [profile.dev]
 codegen-units = 1
 debug = 2
@@ -40,6 +41,7 @@ incremental = false
 opt-level = 3 # <-
 overflow-checks = true # <-
 
+# cargo test
 [profile.test]
 codegen-units = 1
 debug = 2
@@ -48,7 +50,18 @@ incremental = false
 opt-level = 3 # <-
 overflow-checks = true # <-
 
+# cargo build/run --release
 [profile.release]
+codegen-units = 1
+debug = 2
+debug-assertions = false # <-
+incremental = false
+lto = 'fat'
+opt-level = 3 # <-
+overflow-checks = false # <-
+
+# cargo test --release
+[profile.bench]
 codegen-units = 1
 debug = 2
 debug-assertions = false # <-


### PR DESCRIPTION
executable build with `cargo test --release` are built with the `bench` profile. By default, this profile is similar to the default `release` profile so it has `debug = 0`. The result is that `cargo test --release` results in (1) log messages having no location information and (2) knurling-rs/probe-run#9, which makes the process exit with nonzero exit code even when all test fails.

this PR overrides the `bench` profile to match the `release` profile override. This fixes above issues.