### PR TITLE
also enable optimizations in the `test` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,14 @@ incremental = false
 opt-level = 3 # <-
 overflow-checks = true # <-
 
+[profile.test]
+codegen-units = 1
+debug = 2
+debug-assertions = true # <-
+incremental = false
+opt-level = 3 # <-
+overflow-checks = true # <-
+
 [profile.release]
 codegen-units = 1
 debug = 2


### PR DESCRIPTION
Cargo doc says:

> Note that when using the cargo test and cargo bench commands, the test/bench profiles only apply to the final test executable. Dependencies will continue to use the dev/release profiles.

So with the current settings, `cargo test` optimizes all dependencies but not the top level
crate (e.g. `test/foo.rs`)

This commit adds optimizations to the last `rustc` invocation of `cargo test`. This results in a 6%
reduction in binary size when doing `cargo test` on our sample test file.