### PR TITLE
Switch from cargo-generate to kickstart

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,1 +1,0 @@
-.github/FUNDING.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # TODO(1) fix `authors` and `name` if you didn't use `cargo-generate`
 authors = ["{{authors}}"]
-name = "{{project-name}}"
+name = "{{project_name}}"
 edition = "2018"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-# TODO(1) fix `authors` and `name` if you didn't use `cargo-generate`
+# TODO(1) fix `authors` and `name` if you didn't use `kickstart`
 authors = ["{{authors}}"]
 name = "{{project_name}}"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -20,25 +20,22 @@ $ cargo install flip-link
 $ cargo install probe-run
 ```
 
-#### 3. [`cargo-generate`]:
+#### 3. [`kickstart`]:
 
 ```
-$ cargo install cargo-generate
+$ cargo install kickstart
 ```
 
-[`cargo-generate`]: https://crates.io/crates/cargo-generate
+[`kickstart`]: https://crates.io/crates/kickstart
 
-> *Note:* You can also just clone this repository instead of using `cargo-generate`, but this involves additional manual adjustments.
+> *Note:* You can also just clone this repository instead of using `kickstart`, but this involves additional manual adjustments.
 
 ## Setup
 
 #### 1. Initialize the project template
 
 ``` console
-$ cargo generate \
-    --git https://github.com/knurling-rs/app-template \
-    --branch main \
-    --name my-app
+$ kickstart https://github.com/knurling-rs/app-template
 ```
 
 If you look into your new `my-app` folder, you'll find that there are a few `TODO`s in the files marking the properties you need to set.

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ Let's walk through them together now.
 
 Pick a chip from `probe-run --list-chips` and enter it into `.cargo/config.toml`.
 
-If, for example, you have a nRF52840 Development Kit from one of [our workshops], replace `{{chip}}` with `nRF52840_xxAA`.
+If, for example, you have a nRF52840 Development Kit from one of [our workshops], replace `$CHIP` with `nRF52840_xxAA`.
 
 [our workshops]: https://github.com/ferrous-systems/embedded-trainings-2020
 
 ``` diff
  # .cargo/config.toml
  [target.'cfg(all(target_arch = "arm", target_os = "none"))']
--runner = "probe-run --chip {{chip}}"
+-runner = "probe-run --chip $CHIP"
 +runner = "probe-run --chip nRF52840_xxAA"
 ```
 

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,2 +1,0 @@
-[template]
-exclude = ["README.md"]

--- a/template.toml
+++ b/template.toml
@@ -1,0 +1,26 @@
+name = "knurling-app-template"
+
+description = """
+Quickly set up a `probe-run` + `defmt` + `flip-link` embedded project
+"""
+
+kickstart_version = 1
+
+ignore = [".github"]
+
+[[variables]]
+name = "project_name"
+prompt = "Enter the project name"
+default = "app-template"
+validation = "^([a-zA-Z_][a-zA-Z0-9_-]+)$"
+
+[[variables]]
+name = "crate_name"
+prompt = "Enter the crate name (usually the project name with `-` replaced by `_`)"
+default = "app_template"
+validation = "^([a-zA-Z_][a-zA-Z0-9_]+)$"
+
+[[variables]]
+name = "authors"
+prompt = "Enter the project authors"
+default = "Nobody <nobody@example.com>"

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -11,7 +11,7 @@ name = "test"
 harness = false
 
 [dependencies]
-{{project-name}} = { path = ".." }
+{{project_name}} = { path = ".." }
 cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
 defmt = "0.1.0"

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-# TODO(1) fix `authors` if you didn't use `cargo-generate`
+# TODO(1) fix `authors` if you didn't use `kickstart`
 authors = ["{{authors}}"]
 name = "testsuite"
 publish = false


### PR DESCRIPTION
[kickstart](https://github.com/Keats/kickstart) is vastly simpler and easier to predict. It shouldn't run into the unreproducible CI errors in https://github.com/knurling-rs/app-template/pull/46.

Drawbacks:
- Author is no longer automatically filled in from git
- We have to ask for both the package name and the crate name, because kickstart does not automatically give you both