### PR TITLE
Disable test harness for lib target

### DIFF
--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 edition = "2018"
 version = "0.1.0"
 
+[lib]
+harness = false
+
 [[test]]
 name = "test"
 harness = false

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+#![cfg_attr(test, no_main)]
+
+use {{crate_name}} as _; // memory layout + panic handler
+
+#[defmt_test::tests]
+mod tests {}


### PR DESCRIPTION
Without this change, if `testsuite/src/lib.rs` will be crated and `cargo
test` is invoked, cargo will try to link libtest with the crate.

As this crate is `no_std` and will usually be run for targets, where no
std library exists and therefor also no libtest, this will fail with an
error similar to this:


    error[E0463]: can't find crate for `test`

    error: aborting due to previous error

    For more information about this error, try `rustc --explain E0463`.
    error: could not compile `testsuite`

To circumvent this issue, disable the harness for lib as well.