### PR TITLE
Updates nrf-hal version to 0.14.0 to resolve dependency conflicts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For the nRF52840 you'll want to use the [`nrf52840-hal`].
  # Cargo.toml
  [dependencies]
 -# some-hal = "1.2.3"
-+nrf52840-hal = "0.12.0"
++nrf52840-hal = "0.14.0"
 ```
 
 #### 5. Import your HAL


### PR DESCRIPTION
Ran into the following conflict:
<img width="1031" alt="Screenshot 2021-11-19 at 15 49 04" src="https://user-images.githubusercontent.com/6567555/142642128-e612ffcc-c15b-4412-b29b-9308e9ab7dad.png">

This update solves it.