### PR TITLE
Fix `lto` option in cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ debug = 2
 debug-assertions = false # <-
 incremental = false
 # see comment in the profile.release section
-lto = 'false'
+lto = false
 opt-level = 3 # <-
 overflow-checks = false # <-
 


### PR DESCRIPTION
`lto = 'false'` breaks build on the current nightly. It has to be `lto = false`, without the `'`.

```console
$ cargo build --bins
   Compiling krate v0.1.0 (/home/urhengulas/Documents/github.com/knurling-rs/krate)
    Finished dev [optimized + debuginfo] target(s) in 0.16s

$ cargo +nightly build --bins
error: failed to parse manifest at `/home/urhengulas/Documents/github.com/knurling-rs/krate/Cargo.toml`

Caused by:
  `lto` setting of string `"false"` for `bench` profile is not a valid setting, must be a boolean (`true`/`false`) or a string (`"thin"`/`"fat"`/`"off"`) or omitted.
```

Raised in https://github.com/knurling-rs/app-template/pull/61#issuecomment-1166687101.