### PR TITLE
Minor fix: Readme to config.toml references

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# TODO(2) replace `$CHIP` with your chip's name (see `probe-run --list-chips` output)
+# TODO(Setup item #2) replace `$CHIP` with your chip's name (see `probe-run --list-chips` output)
 runner = "probe-run --chip $CHIP"
 rustflags = [
   "-C", "linker=flip-link",
@@ -11,7 +11,7 @@ rustflags = [
 ]
 
 [build]
-# TODO(3) Adjust the compilation target.
+# TODO(Setup item #3) Adjust the compilation target.
 # (`thumbv6m-*` is compatible with all ARM Cortex-M chips but using the right
 # target improves performance)
 target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+

--- a/README.md
+++ b/README.md
@@ -50,29 +50,30 @@ Let's walk through them together now.
 
 Pick a chip from `probe-run --list-chips` and enter it into `.cargo/config.toml`.
 
-If, for example, you have a nRF52840 Development Kit from one of [our workshops], replace `{{chip}}` with `nRF52840_xxAA`.
+If, for example, you have a nRF52840 Development Kit from one of [our workshops], replace `$CHIP` with `nRF52840_xxAA`.
 
 [our workshops]: https://github.com/ferrous-systems/embedded-trainings-2020
 
 ``` diff
  # .cargo/config.toml
  [target.'cfg(all(target_arch = "arm", target_os = "none"))']
--runner = "probe-run --chip {{chip}}"
+-runner = "probe-run --chip $CHIP"
 +runner = "probe-run --chip nRF52840_xxAA"
 ```
 
 #### 3. Adjust the compilation target
 
-In `.cargo/config.toml`, pick the right compilation target for your board.
+In `.cargo/config.toml`, pick the right compilation target for your board. The example below, disables default target (`thumbv6m-none-eabi`) and enables `thumbv7em-none-eabihf`.
 
 ``` diff
  # .cargo/config.toml
  [build]
 -target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
--# target = "thumbv7m-none-eabi"    # Cortex-M3
--# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
++# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
 -# target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
-+target = "thumbv7em-none-eabihf" # Cortex-M4F (with FPU)
++target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 ```
 
 Add the target with `rustup`.


### PR DESCRIPTION
Improved README to point correct references in the config.toml file. Minor issues on target selection has been fixed regarding to default config.

@Urhengulas : Why are you closing a PR with a small issue that fast? You could ask for a fix and it could be done in a minute. That's what PR's discussions for.