### PR TITLE
Update `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,12 +49,9 @@ codegen-units = 1
 debug = 2
 debug-assertions = false # <-
 incremental = false
-# NOTE disabled to work around issue rust-lang/rust#90357
-# the bug results in log messages not having location information
-# (the line printed below the log message that contains the file-line location)
-# lto = 'fat'
-opt-level = 3           # <-
-overflow-checks = false # <-
+lto = 'fat'
+opt-level = 3            # <-
+overflow-checks = false  # <-
 
 # cargo test --release
 [profile.bench]
@@ -62,10 +59,9 @@ codegen-units = 1
 debug = 2
 debug-assertions = false # <-
 incremental = false
-# see comment in the profile.release section
-lto = false
-opt-level = 3           # <-
-overflow-checks = false # <-
+lto = 'fat'
+opt-level = 3            # <-
+overflow-checks = false  # <-
 
 # uncomment this to switch from the crates.io version of defmt to its git version
 # check app-template's README for instructions


### PR DESCRIPTION
Update to the new `defmt-rtt` version, re-enable `lto` and `opt-level` after they got dixed upstream and some drive-by changes.

Fixes #5, #63.