### PR TITLE
Use semihosting to exit the test program.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ cortex-m-rt = "0.7"
 defmt = "0.3"
 defmt-rtt = "0.4"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
+cortex-m-semihosting = "0.5.0"
 # TODO(4) enter your HAL here
 # some-hal = "1.2.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_main]
 #![no_std]
 
+use cortex_m_semihosting::debug;
+
 use defmt_rtt as _; // global logger
 
 // TODO(5) adjust HAL import
@@ -18,9 +20,20 @@ fn panic() -> ! {
 /// Terminates the application and makes a semihosting-capable debug tool exit
 /// with status code 0.
 pub fn exit() -> ! {
-    use cortex_m_semihosting::debug;
     loop {
         debug::exit(debug::EXIT_SUCCESS);
+    }
+}
+
+/// Hardfault handler.
+///
+/// Terminates the application and makes a semihosting-capable debug tool exit
+/// with an error. This seems better than the default, which is to spin in a
+/// loop.
+#[cortex_m_rt::exception]
+unsafe fn HardFault(_frame: &cortex_m_rt::ExceptionFrame) -> ! {
+    loop {
+        debug::exit(debug::EXIT_FAILURE);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,12 @@ fn panic() -> ! {
     cortex_m::asm::udf()
 }
 
-/// Terminates the application and makes `probe-run` exit with exit-code = 0
+/// Terminates the application and makes a semihosting-capable debug tool exit
+/// with status code 0.
 pub fn exit() -> ! {
+    use cortex_m_semihosting::debug;
     loop {
-        cortex_m::asm::bkpt();
+        debug::exit(debug::EXIT_SUCCESS);
     }
 }
 


### PR DESCRIPTION
Instead of a plain breakpoint, try and give the debugger some idea of why we stopped.

Supported by QEMU, patching being added to probe-rs and ignored by probe-run.