### PR TITLE
ignore binary targets from test to be able to run all the tests via `…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,43 @@ name = "{{project-name}}"
 edition = "2021"
 version = "0.1.0"
 
+
+# To run all the tests via `cargo test` the tests need to be explicitly disabled for the binary targets
+# If you use a standard main.rs file the following is sufficient:
+# [[bin]]
+# name = "{{project-name}}"
+# test = false
+
+[[bin]]
+name = "bitfield"
+path = "src/bin/bitfield.rs"
+test = false
+
+[[bin]]
+name = "format"
+path = "src/bin/format.rs"
+test = false
+
+[[bin]]
+name = "hello"
+path = "src/bin/hello.rs"
+test = false
+
+[[bin]]
+name = "levels"
+path = "src/bin/levels.rs"
+test = false
+
+[[bin]]
+name = "overflow"
+path = "src/bin/overflow.rs"
+test = false
+
+[[bin]]
+name = "panic"
+path = "src/bin/panic.rs"
+test = false
+
 [lib]
 harness = false
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ all tests passed!
 
 Note that to add a new test file to the `tests` directory you also need to add a new `[[test]]` section to `Cargo.toml`.
 
+To run all the tests via `cargo test` the tests need to be explicitly disabled for all the existing binary targets.
+See `Cargo.toml` for details on how to do this.
+
 ## Support
 
 `app-template` is part of the [Knurling] project, [Ferrous Systems]' effort at


### PR DESCRIPTION
By explictly disabling the test for the binary targets, as mentioned [here](https://github.com/knurling-rs/defmt/issues/885), all tests can be run via `cargo test` instead of the separate commands `cargo test --lib`, `cargo test --test integration` and so on

