### PR TITLE
Rename checkOnSave to check in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
     // override the default setting (`cargo check --all-targets`) which produces the following error
     // "can't find crate for `test`" when the default compilation target is a no_std target
     // with these changes RA will call `cargo check --bins` on save
-    "rust-analyzer.checkOnSave.allTargets": false,
-    "rust-analyzer.checkOnSave.extraArgs": [
+    "rust-analyzer.check.allTargets": false,
+    "rust-analyzer.check.extraArgs": [
         "--bins"
     ]
 }


### PR DESCRIPTION
This setting was renamed in https://github.com/rust-lang/rust-analyzer/pull/13799 (2023-01-09).

rust-analyzer still understands the old values, but you will see an error message in VSCode with the old option naming: "invalid config value: /checkOnSave: invalid type: map, expected a boolean;", plus it made it so the settings made did not show up in the graphical VSCode settings editor.