### PR TITLE
Clean ups and updates.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # TODO(2) replace `$CHIP` with your chip's name (see `probe-rs chip list` output)
-runner = "probe-rs run --chip $CHIP"
-# runner = ["probe-rs", "run", "--chip", "$CHIP", "--log-format", "{L} {s}"]
+runner = ["probe-rs", "run", "--chip", "$CHIP", "--log-format=oneline"]
+# If you have an nRF52, you might also want to add "--allow-erase-all" to the list
 
 rustflags = [
   "-C", "linker=flip-link",
@@ -14,13 +14,14 @@ rustflags = [
 
 [build]
 # TODO(3) Adjust the compilation target.
-# (`thumbv6m-*` is compatible with all ARM Cortex-M chips but using the right
-# target improves performance)
+# Select the correct target for your processor:
 target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
 # target = "thumbv7m-none-eabi"    # Cortex-M3
 # target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
 # target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 
 [alias]
+# `cargo rb foo` will expand to `cargo run --bin foo`
 rb = "run --bin"
+# `cargo rrb foo` will expand to `cargo run --release --bin foo`
 rrb = "run --release --bin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,6 @@
 # TODO(1) fix `authors` and `name` if you didn't use `cargo-generate`
 authors = ["{{authors}}"]
 name = "{{project-name}}"
-
-# Ferocene only supports up to 2021 edition
-#edition = "2021"
-# Many embedded developers don't use Ferocene, so they could benefit from the latest Rust features 
 edition = "2024"
 version = "0.1.0"
 
@@ -60,7 +56,7 @@ cortex-m-rt = "0.7"
 defmt = "1.0"
 defmt-rtt = "1.0"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
-cortex-m-semihosting = "0.5.0"
+semihosting = "0.1.20"
 # TODO(4) enter your HAL here
 # some-hal = "1.2.3"
 
@@ -69,39 +65,21 @@ defmt-test = "0.3"
 
 # cargo build/run
 [profile.dev]
+# default is opt-level = '0', but that makes very
+# verbose machine code
+opt-level = 's'
+# trade compile speed for slightly better optimisations
 codegen-units = 1
-debug = 2
-debug-assertions = true # <-
-incremental = false
-opt-level = 'z'         # <-
-overflow-checks = true  # <-
-
-# cargo test
-[profile.test]
-codegen-units = 1
-debug = 2
-debug-assertions = true # <-
-incremental = false
-opt-level = 3           # <-
-overflow-checks = true  # <-
 
 # cargo build/run --release
 [profile.release]
+# default is opt-level = '3', but that makes quite
+# verbose machine code
+opt-level = 's'
+# trade compile speed for slightly better optimisations
 codegen-units = 1
-debug = 2
-debug-assertions = false # <-
-incremental = false
+# Use Link Time Optimisations to further inline things across
+# crates
 lto = 'fat'
-opt-level = 3            # <-
-overflow-checks = false  # <-
-
-# cargo test --release
-[profile.bench]
-codegen-units = 1
+# Leave the debug symbols in (default is no debug info)
 debug = 2
-debug-assertions = false # <-
-incremental = false
-lto = 'fat'
-opt-level = 3            # <-
-overflow-checks = false  # <-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_main]
 #![no_std]
 
-use cortex_m_semihosting::debug;
-
 use defmt_rtt as _; // global logger
 
 // TODO(5) adjust HAL import
@@ -20,9 +18,7 @@ fn panic() -> ! {
 /// Terminates the application and makes a semihosting-capable debug tool exit
 /// with status code 0.
 pub fn exit() -> ! {
-    loop {
-        debug::exit(debug::EXIT_SUCCESS);
-    }
+    semihosting::process::exit(0);
 }
 
 /// Hardfault handler.
@@ -32,9 +28,7 @@ pub fn exit() -> ! {
 /// loop.
 #[cortex_m_rt::exception]
 unsafe fn HardFault(_frame: &cortex_m_rt::ExceptionFrame) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE);
-    }
+    semihosting::process::exit(1);
 }
 
 // defmt-test 0.3.0 has the limitation that this `#[tests]` attribute can only be used


### PR DESCRIPTION
* Use oneline as the default log format
* Note that nRF52 needs --allow-erase-all
* Cortex-M targets are not perfectly backwards compatible
* Explain the aliases
* Clean up the dev/release options, removing the values that were the defaults anyway
* Switch to the semihosting crate, because it supports more architectures
* Fix link to old training
